### PR TITLE
feat: Redirect application logs to a 'Journal Système' tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import Sessions from './pages/Sessions';
 import Exams from './pages/Exams';
 import Reports from './pages/Reports';
 import Settings from './pages/Settings';
-import LogViewer from './components/log/AppLogViewer';
 import { logger } from './utils/logger';
 
 function App() {
@@ -41,7 +40,6 @@ function App() {
   return (
     <div className="font-sans antialiased text-gray-900 bg-gray-50">
       {renderPage()}
-      <LogViewer />
     </div>
   );
 }

--- a/src/components/settings/SystemLogViewer.tsx
+++ b/src/components/settings/SystemLogViewer.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect } from 'react';
+import { useLogStore } from '../../stores/logStore';
+import { LogEntry } from '../../utils/logger';
+import Button from '../ui/Button'; // Assuming a Button component exists
+import { RefreshCw, Trash2 } from 'lucide-react'; // Icons for buttons
+
+const SystemLogViewer: React.FC = () => {
+  const { logs, fetchLogs, clearLogs } = useLogStore();
+
+  useEffect(() => {
+    fetchLogs(); // Initial fetch of logs when component mounts
+  }, [fetchLogs]);
+
+  const handleRefreshLogs = () => {
+    fetchLogs();
+  };
+
+  const handleClearLogs = () => {
+    clearLogs();
+    // fetchLogs(); // logStore.clearLogs() already clears and fetches
+  };
+
+  const getLogLevelColor = (level: LogEntry['level']) => {
+    switch (level) {
+      case 'INFO': return 'text-blue-600';
+      case 'WARNING': return 'text-yellow-600';
+      case 'ERROR': return 'text-red-600';
+      case 'SUCCESS': return 'text-green-600';
+      default: return 'text-gray-800';
+    }
+  };
+
+  return (
+    <div className="p-4 bg-white shadow rounded-lg">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-lg font-medium text-gray-900">Journal des événements système</h3>
+        <div className="space-x-2">
+          <Button variant="outline" onClick={handleRefreshLogs} icon={<RefreshCw size={16} />}>
+            Rafraîchir
+          </Button>
+          <Button variant="destructive" onClick={handleClearLogs} icon={<Trash2 size={16} />}>
+            Effacer les logs
+          </Button>
+        </div>
+      </div>
+      <div className="max-h-96 overflow-y-auto border border-gray-200 rounded p-2 bg-gray-50">
+        {logs.length === 0 ? (
+          <p className="text-gray-500 text-center py-4">Aucun log disponible.</p>
+        ) : (
+          <ul className="divide-y divide-gray-200">
+            {logs.map((log, index) => (
+              <li key={index} className="py-2 px-1 text-sm">
+                <span className={`font-semibold ${getLogLevelColor(log.level)}`}>[{log.level}]</span>
+                <span className="text-gray-500 ml-2 mr-2">{log.timestamp}</span>
+                <span>{log.message}</span>
+                {log.details && typeof log.details === 'object' && log.details !== null && (
+                  <pre className="ml-4 mt-1 text-xs bg-gray-100 p-2 rounded overflow-x-auto">
+                    {(() => {
+                      try {
+                        return JSON.stringify(log.details, null, 2);
+                      } catch (e) {
+                        return 'Error: Unable to serialize details';
+                      }
+                    })()}
+                  </pre>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SystemLogViewer;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -2,9 +2,10 @@ import React, { useState } from 'react';
 import Layout from '../components/layout/Layout';
 import DeviceSettings from '../components/settings/DeviceSettings';
 import GeneralSettings from '../components/settings/GeneralSettings';
+import SystemLogViewer from '../components/settings/SystemLogViewer';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
-import { Settings as SettingsIcon, Usb, Save } from 'lucide-react';
+import { Settings as SettingsIcon, Usb, Save, ScrollText } from 'lucide-react';
 
 type SettingsProps = {
   activePage: string;
@@ -12,11 +13,12 @@ type SettingsProps = {
 };
 
 const Settings: React.FC<SettingsProps> = ({ activePage, onPageChange }) => {
-  const [activeTab, setActiveTab] = useState<'general' | 'devices'>('general');
+  const [activeTab, setActiveTab] = useState<'general' | 'devices' | 'system_log'>('general');
 
   const tabs = [
     { id: 'general', label: 'Paramètres généraux', icon: <SettingsIcon size={20} /> },
     { id: 'devices', label: 'Configuration des boîtiers', icon: <Usb size={20} /> },
+    { id: 'system_log', label: 'Journal Système', icon: <ScrollText size={20} /> },
   ];
 
   const headerActions = (
@@ -39,7 +41,7 @@ const Settings: React.FC<SettingsProps> = ({ activePage, onPageChange }) => {
             {tabs.map((tab) => (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id as 'general' | 'devices')}
+                onClick={() => setActiveTab(tab.id as 'general' | 'devices' | 'system_log')}
                 className={`
                   flex items-center py-4 px-1 border-b-2 font-medium text-sm
                   ${activeTab === tab.id
@@ -58,6 +60,7 @@ const Settings: React.FC<SettingsProps> = ({ activePage, onPageChange }) => {
         <div className="mt-6">
           {activeTab === 'general' && <GeneralSettings />}
           {activeTab === 'devices' && <DeviceSettings />}
+          {activeTab === 'system_log' && <SystemLogViewer />}
         </div>
       </Card>
     </Layout>

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import { format } from 'date-fns';
+import { useLogStore } from '../stores/logStore';
 
 export type LogLevel = 'INFO' | 'WARNING' | 'ERROR' | 'SUCCESS';
 
@@ -52,6 +53,7 @@ class Logger {
     }
 
     this.logs.push(entry);
+    useLogStore.getState().fetchLogs();
     this.persistLog(entry);
   }
 


### PR DESCRIPTION
This commit addresses the issue of the intrusive application log overlay.

Key changes:
- Modified `utils/logger.ts` to integrate with `stores/logStore.ts`, ensuring logs are centrally available.
- Created a new `components/settings/SystemLogViewer.tsx` component to display logs within a dedicated tab in the settings page.
- Updated `pages/Settings.tsx` to add the 'Journal Système' tab and render the new log viewer.
- Removed the old `components/log/AppLogViewer.tsx` component from the main application layout (`App.tsx`), thereby removing the intrusive overlay.

Logs are now accessible via the 'Journal Système' tab in the application settings, providing a cleaner user experience. Manual testing should be performed to confirm all functionalities.