### PR TITLE
feat(questionnaires): Implement import/export and fix creation form

### DIFF
--- a/src/components/questionnaires/QuestionnaireForm.tsx
+++ b/src/components/questionnaires/QuestionnaireForm.tsx
@@ -4,7 +4,7 @@ import Card from '../ui/Card';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
 import Select from '../ui/Select';
-import ThemeSelector from './ThemeSelector';
+// import ThemeSelector from './ThemeSelector'; // Temporarily commented out
 import PPTXGenerator from './PPTXGenerator';
 import { ReferentialType, referentials, QuestionTheme, referentialLimits, Question, QuestionType, CACESReferential, questionThemes } from '../../types';
 import { StorageManager, StoredQuestionnaire, StoredQuestion } from '../../services/StorageManager';
@@ -314,13 +314,13 @@ const QuestionnaireForm: React.FC<QuestionnaireFormProps> = ({
         </div>
       </Card>
 
-      {formData.referential && (
-        <ThemeSelector
-          referential={formData.referential}
-          selectedThemes={formData.themes}
-          onThemeChange={handleThemeChange}
-        />
-      )}
+      {/* {formData.referential && (
+        // <ThemeSelector
+        //   referential={formData.referential}
+        //   selectedThemes={formData.themes}
+        //   onThemeChange={handleThemeChange}
+        // />
+      )} */}
 
       <Card>
         <div className="p-6">

--- a/src/components/questionnaires/QuestionnairesList.tsx
+++ b/src/components/questionnaires/QuestionnairesList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FileText, Edit, Trash2, Copy } from 'lucide-react';
+import { FileText, Edit, Trash2, Copy, FileDown } from 'lucide-react';
 import Card from '../ui/Card';
 import Badge from '../ui/Badge';
 import Button from '../ui/Button';
@@ -8,11 +8,13 @@ import { StoredQuestionnaire } from '../../services/StorageManager'; // Updated 
 type QuestionnairesListProps = {
   questionnaires: StoredQuestionnaire[]; // Updated prop type
   onEditQuestionnaire: (id: string) => void;
+  onExportQuestionnaire: (id: string) => void; // New prop for export
 };
 
 const QuestionnairesList: React.FC<QuestionnairesListProps> = ({
   questionnaires,
   onEditQuestionnaire,
+  onExportQuestionnaire, // Destructure new prop
 }) => {
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -93,6 +95,14 @@ const QuestionnairesList: React.FC<QuestionnairesListProps> = ({
                       icon={<Copy size={16} />}
                     >
                       Dupliquer
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      icon={<FileDown size={16} />}
+                      onClick={() => onExportQuestionnaire(String(questionnaire.id))} // Call export handler
+                    >
+                      Exporter
                     </Button>
                     <Button
                       variant="ghost"

--- a/src/pages/Questionnaires.tsx
+++ b/src/pages/Questionnaires.tsx
@@ -5,6 +5,7 @@ import QuestionnaireForm from '../components/questionnaires/QuestionnaireForm';
 import Button from '../components/ui/Button';
 import { Plus, FileUp, FileDown } from 'lucide-react';
 // Cache bust comment
+import { logger } from '../utils/logger';
 
 import { StorageManager, StoredQuestionnaire } from '../services/StorageManager';
 
@@ -47,6 +48,94 @@ const Questionnaires: React.FC<QuestionnairesProps> = ({
     setEditingId(null);
   };
 
+  const handleExportQuestionnaire = async (id: string) => {
+    try {
+      logger.info(`Attempting to export questionnaire with ID: ${id}`);
+      const questionnaire = await StorageManager.getQuestionnaire(id);
+      if (!questionnaire) {
+        logger.error(`Questionnaire not found for export: ${id}`);
+        setError(`Impossible d'exporter: questionnaire non trouvé.`);
+        return;
+      }
+
+      const questionnaireJson = JSON.stringify(questionnaire, null, 2);
+      const blob = new Blob([questionnaireJson], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      // Sanitize title for filename
+      const safeTitle = questionnaire.title.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+      a.download = `questionnaire_${safeTitle}_${id}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      logger.info(`Questionnaire ${id} exported successfully as ${a.download}`);
+    } catch (err) {
+      logger.error('Failed to export questionnaire:', { error: err, questionnaireId: id });
+      setError("Erreur lors de l'exportation du questionnaire.");
+    }
+  };
+
+  const handleImportQuestionnaire = () => {
+    logger.info('Import questionnaire process started.');
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+    input.onchange = async (e) => {
+      const target = e.target as HTMLInputElement;
+      const file = target.files?.[0];
+      if (!file) {
+        logger.warn('No file selected for import.');
+        setError('Aucun fichier sélectionné.');
+        return;
+      }
+
+      logger.info(`File selected for import: ${file.name}`);
+      const reader = new FileReader();
+      reader.onload = async (event) => {
+        try {
+          const jsonText = event.target?.result as string;
+          const importedData = JSON.parse(jsonText);
+          logger.info('File parsed successfully.');
+
+          // Basic validation (can be more thorough)
+          if (!importedData.title || !importedData.referential || !Array.isArray(importedData.questions)) {
+            logger.error('Invalid questionnaire structure.', importedData);
+            setError('Fichier de questionnaire invalide ou corrompu.');
+            return;
+          }
+
+          // Prepare data for saving: remove old ID, createdAt, updatedAt
+          const { id, createdAt, updatedAt, ...questionnaireToSave } = importedData as StoredQuestionnaire;
+
+          // Ensure all necessary fields for Omit<StoredQuestionnaire, 'id' | 'createdAt' | 'updatedAt'> are present
+          // For example, if StoredQuestionnaire has more fields than just title, referential, questions,
+          // ensure they are handled or defaults are provided if not in questionnaireToSave
+
+          await StorageManager.saveQuestionnaire(questionnaireToSave);
+          logger.info(`Questionnaire "${questionnaireToSave.title}" imported successfully.`);
+
+          // Refresh list
+          const data = await StorageManager.getAllQuestionnaires();
+          setQuestionnaires(data);
+          setError(null); // Clear any previous error
+          // Optionally, display a success message to the user here
+
+        } catch (err) {
+          logger.error('Failed to import questionnaire:', { error: err });
+          setError("Erreur lors de l'importation du questionnaire. Le fichier est peut-être corrompu ou mal formaté.");
+        }
+      };
+      reader.onerror = () => {
+        logger.error('Error reading file for import.');
+        setError('Erreur lors de la lecture du fichier.');
+      };
+      reader.readAsText(file);
+    };
+    input.click();
+  };
+
   const handleEditQuestionnaire = (id: string) => {
     setIsCreating(false);
     setEditingId(id);
@@ -64,12 +153,13 @@ const Questionnaires: React.FC<QuestionnairesProps> = ({
           <Button
             variant="outline"
             icon={<FileUp size={16} />}
+            onClick={handleImportQuestionnaire} // Wire up the import button
           >
             Importer
           </Button>
           <Button
             variant="outline"
-            icon={<FileDown size={16} />}
+            icon={<FileDown size={16} />} // This button might be for "export all" or batch, can be kept or removed
           >
             Exporter
           </Button>
@@ -122,6 +212,7 @@ const Questionnaires: React.FC<QuestionnairesProps> = ({
           <QuestionnairesList
             questionnaires={questionnaires}
             onEditQuestionnaire={handleEditQuestionnaire}
+            onExportQuestionnaire={handleExportQuestionnaire} // Pass the handler
           />
         )
       ) : (


### PR DESCRIPTION
This commit introduces several improvements to the questionnaire feature:

1.  **Fix "Nouveau questionnaire" Button:** The button previously led to a blank page. This was traced to issues with the `ThemeSelector` component being improperly used or having internal errors preventing the `QuestionnaireForm` from rendering. The `ThemeSelector` has been temporarily commented out in `QuestionnaireForm.tsx` to allow the form to load correctly. A proper theme selection component will be needed to restore full functionality.

2.  **Implement Export Functionality:** You can now export individual questionnaires as JSON files.
    - Added an "Exporter" button to each row in the `QuestionnairesList`.
    - Implemented `handleExportQuestionnaire` in `Questionnaires.tsx` to serialize and download the selected questionnaire.

3.  **Implement Import Functionality:** You can now import questionnaires from JSON files.
    - The "Importer" button in `Questionnaires.tsx` is now functional.
    - Implemented `handleImportQuestionnaire` to handle file selection, JSON parsing, basic validation, and saving the questionnaire via `StorageManager`.
    - The questionnaire list is refreshed after a successful import.