### PR TITLE
fix: Resolve blank page on add custom question and multiple type errors

### DIFF
--- a/src/components/questionnaires/ThemeSelector.tsx
+++ b/src/components/questionnaires/ThemeSelector.tsx
@@ -120,7 +120,7 @@ const ThemeSelector: React.FC<ThemeSelectorProps> = ({
         )}
 
         <div className="bg-blue-50 p-4 rounded-lg mt-4">
-          <p className="text-sm text-blue-800">
+          <div className="text-sm text-blue-800"> {/* Changed p to div */}
             <strong>Recommandations Cnam :</strong>
             <ul className="mt-2 list-disc list-inside">
               <li>20-50 questions au total selon le référentiel</li>
@@ -128,7 +128,7 @@ const ThemeSelector: React.FC<ThemeSelectorProps> = ({
               <li>≥70% pour réussir l'examen</li>
               <li>≥50% par thème</li>
             </ul>
-          </p>
+          </div> {/* Changed p to div */}
         </div>
       </div>
     </Card>

--- a/src/db.ts
+++ b/src/db.ts
@@ -12,10 +12,11 @@ export interface QuestionWithId {
   correctAnswer: string; // Storing the answer text or a key that maps to it
   timeLimit?: number;
   isEliminatory: boolean;
-  referential: ReferentialType; // Using imported ReferentialType
+  referential: CACESReferential; // Standardize to CACESReferential enum
   theme: QuestionTheme;         // Using imported QuestionTheme
   image?: Blob | null; // Allow null for easier clearing, Blob for storage
   createdAt?: string;
+  updatedAt?: string; // Add missing field
   usageCount?: number;
   correctResponseRate?: number;
 }
@@ -23,7 +24,7 @@ export interface QuestionWithId {
 export interface QuestionnaireWithId {
   id?: number; // auto-incremented primary key
   name: string;
-  referential: ReferentialType; // Or use `ReferentialType` if appropriate and already defined broadly
+  referential: CACESReferential; // Standardize to CACESReferential enum
   passingThreshold: number;
   themeDistribution: Record<QuestionTheme, number>; // Or `Record<QuestionTheme, number>`
   isRandomized: boolean;


### PR DESCRIPTION
This commit addresses several critical issues:

1.  **Resolved Blank Page Issue:**
    *   Corrected the import and usage of the shared `QuestionForm` component (`src/components/library/QuestionForm.tsx`) within `QuestionnaireForm.tsx`. It was previously being accessed incorrectly, leading to a rendering error and a blank page when trying to add a custom question.

2.  **TypeScript Error Corrections in `library/QuestionForm.tsx`:**
    *   Ensured `updatedAt` field is correctly initialized in the question state.
    *   Corrected type comparisons for `question.type` to prevent logical errors.
    *   Standardized usage of `QuestionType.TrueFalse` enum member.
    *   Replaced invalid `logger.warn` calls with appropriate alternatives.
    *   Fixed `Cannot find name 'initialQuestionState'` errors by correctly calling `getInitialState()`.
    *   Improved handling of potentially undefined `question.timeLimit`.
    *   Removed several unused imports.

3.  **TypeScript Error Corrections in `QuestionnaireForm.tsx`:**
    *   Corrected the import path for the `StoredQuestion` type.
    *   Addressed `ReferentialType` vs. `CACESReferential` incompatibilities by standardizing on `CACESReferential`.
    *   Fixed `logger.warn` calls.
    *   Ensured `questionnaireDataToSave` is not used before assignment.
    *   Removed unused variable imports.

4.  **Database Type Update (`db.ts`):**
    *   Added `updatedAt` to the `QuestionWithId` interface.
    *   Standardized `referential` field to use `CACESReferential` in `QuestionWithId` and `QuestionnaireWithId`.

5.  **DOM Nesting Fix (`ThemeSelector.tsx`):**
    *   Corrected a `validateDOMNesting` warning by changing a `<p>` tag that improperly contained a `<ul>` to a `<div>`.

These changes significantly improve the stability, type safety, and correctness of the questionnaire creation and management features. The primary bug causing a blank page when adding custom questions is now resolved.