### PR TITLE
fix: Resolve multiple TypeScript errors across report components

### DIFF
--- a/src/components/reports/BlockReport.tsx
+++ b/src/components/reports/BlockReport.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import Card from '../ui/Card';
 import { getAllSessions, getAllResults, getAllQuestions, getAllReferentiels, getAllThemes, getAllBlocs } from '../../db';
-import { Session, SessionResult, QuestionWithId, Referential, Theme, Bloc, CalculatedBlockOverallStats } from '../../types'; // Ajout des types
+import { Session, SessionResult, Referential, Theme, Bloc, QuestionWithId, CalculatedBlockOverallStats } from '../../types'; // QuestionWithId et CalculatedBlockOverallStats importés de types
 import {
   Table,
   TableHeader,

--- a/src/components/reports/BlockUsageReport.tsx
+++ b/src/components/reports/BlockUsageReport.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react';
-import { BlockUsage, calculateBlockUsage, getAllReferentiels } from '../../db'; // Ajout de getAllReferentiels
-import { CACESReferential, Referential } from '../../types'; // Ajout de Referential
+import React, { useState, useEffect, useMemo } from 'react';
+import { BlockUsage, calculateBlockUsage, getAllReferentiels } from '../../db';
+import { CACESReferential, Referential } from '../../types';
 
 // Importer les composants UI réutilisables
 import Card from '../ui/Card';

--- a/src/components/reports/GlobalStats.tsx
+++ b/src/components/reports/GlobalStats.tsx
@@ -20,12 +20,14 @@ const GlobalStats: React.FC<GlobalStatsProps> = ({ sessions }) => {
       let sessionsCounted = 0;
 
       for (const session of completedSessions) {
-        if (session.id) {
+        if (session.id && session.selectedBlocIds) { // Vérifier aussi selectedBlocIds pour pertinence
           const results = await getResultsForSession(session.id);
-          const questions = await getQuestionsForSessionBlocks(session.selectionBlocs || []);
-          const stats = calculateSessionStats(session, results, questions);
-          totalSuccessRates += stats.successRate;
-          sessionsCounted++;
+          const questions = await getQuestionsForSessionBlocks(session.selectedBlocIds); // Pas besoin de || [] si on vérifie avant
+          if (questions.length > 0) { // S'assurer qu'il y a des questions pour calculer les stats
+            const stats = calculateSessionStats(session, results, questions);
+            totalSuccessRates += stats.successRate;
+            sessionsCounted++;
+          }
         }
       }
 
@@ -36,12 +38,16 @@ const GlobalStats: React.FC<GlobalStatsProps> = ({ sessions }) => {
       }
     };
 
-    calculateOverallStats();
-  }, [sessions]);
+    if (completedSessions.length > 0) {
+      calculateOverallStats();
+    } else {
+      setAvgSuccessRate(0);
+    }
+  }, [completedSessions]);
 
   const totalSessions = completedSessions.length;
   const totalParticipants = completedSessions.reduce((acc, session) => acc + (session.participants?.length || 0), 0);
-  const activeReferentials = new Set(completedSessions.map(s => s.referentiel)).size;
+  const activeReferentials = new Set(completedSessions.map(s => s.referentielId)).size;
 
   return (
     <div className="mb-8">

--- a/src/components/reports/ReferentialReport.tsx
+++ b/src/components/reports/ReferentialReport.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import Card from '../ui/Card';
-import { getAllSessions, getAllResults, getQuestionsForSessionBlocks, getAllThemes, getAllBlocs, getReferentialById } from '../../db'; // Ajout de getAllThemes, getAllBlocs, getReferentialById
-import { Session, SessionResult, QuestionWithId, Referential, Theme, Bloc, OverallThemeStats } from '../../types'; // Ajout de Theme, Bloc, OverallThemeStats
+import { getAllSessions, getAllResults, getAllThemes, getAllBlocs, getReferentialById, getQuestionsForSessionBlocks } from '../../db'; // getQuestionsForSessionBlocks ré-ajouté car utilisé
+import { Session, SessionResult, Referential, Theme, Bloc, QuestionWithId, OverallThemeStats } from '../../types';
 import {
   Table,
   TableHeader,
@@ -10,9 +10,9 @@ import {
   TableHead,
   TableCell,
 } from '../ui/Table';
-import { calculateSessionStats, calculateOverallThemeStats } from '../../utils/reportCalculators'; // Ajout de calculateOverallThemeStats
-import Button from '../ui/Button'; // Ajouté
-import { ArrowLeft, Eye } from 'lucide-react'; // Ajouté
+import { calculateSessionStats, calculateOverallThemeStats } from '../../utils/reportCalculators';
+import Button from '../ui/Button';
+import { ArrowLeft } from 'lucide-react'; // Eye retiré car le bouton a été retiré/modifié
 
 type ReferentialReportProps = {
   startDate?: string;
@@ -52,29 +52,8 @@ const ReferentialReport: React.FC<ReferentialReportProps> = ({ startDate, endDat
     fetchData();
   }, []);
 
-  // Calcul des questions uniques après que les sessions soient potentiellement filtrées par date
-  const relevantQuestions = useMemo(() => {
-    const filteredSessions = sessions.filter(session => {
-      if (session.status !== 'completed') return false;
-      if (!startDate && !endDate) return true;
-      const sessionDate = new Date(session.dateSession);
-      if (startDate && sessionDate < new Date(startDate)) return false;
-      if (endDate) {
-        const endOfDayEndDate = new Date(endDate);
-        endOfDayEndDate.setHours(23, 59, 59, 999);
-        if (sessionDate > endOfDayEndDate) return false;
-      }
-      return true;
-    });
-    const allUniqueBlocIds = Array.from(new Set(filteredSessions.flatMap(s => s.selectedBlocIds || []).filter(id => id != null)));
-    // Note: getQuestionsForSessionBlocks est async, ne peut pas être dans useMemo directement sans un useEffect pour le résultat
-    // Pour l'instant, on va supposer que allQuestions est chargé globalement ou on adapte.
-    // Alternative: charger toutes les questions une fois et filtrer ici.
-    // Pour simplifier, on utilise allQuestions chargé dans le useEffect initial (qui charge TOUTES les questions)
-    // Ce n'est pas optimal si les dates changent souvent, mais suffisant pour l'instant.
-    return allQuestions.filter(q => q.blocId && allUniqueBlocIds.includes(q.blocId));
-  }, [sessions, startDate, endDate, allQuestions]);
-
+  // relevantQuestions n'est plus utilisé, les questions sont filtrées dans overallThemeStatsForSelectedReferential
+  // const relevantQuestions = useMemo(() => { ... });
 
   const statsByReferential = useMemo(() => {
     const filteredSessions = sessions.filter(session => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,33 +1,12 @@
 import Dexie, { Table } from 'dexie';
-import { CACESReferential, Session, Participant, SessionResult, Trainer, SessionQuestion, SessionBoitier, Referential, Theme, Bloc } from './types'; // Ajout de Referential, Theme, Bloc
+import {
+  CACESReferential, Session, Participant, SessionResult, Trainer,
+  SessionQuestion, SessionBoitier, Referential, Theme, Bloc,
+  QuestionWithId, VotingDevice // Types maintenant importés
+} from './types';
 import { logger } from './utils/logger'; // Importer le logger
 
-// Interfaces pour la DB
-export interface QuestionWithId {
-  id?: number;
-  text: string;
-  type: 'multiple-choice' | 'true-false';
-  options: string[];
-  correctAnswer: string;
-  timeLimit?: number;
-  isEliminatory: boolean;
-  // referential: CACESReferential | string; // Supprimé
-  // theme: string; // Supprimé
-  blocId?: number; // Ajouté
-  image?: Blob | null;
-  createdAt?: string;
-  updatedAt?: string;
-  usageCount?: number;
-  correctResponseRate?: number;
-  slideGuid?: string;
-  imageName?: string; // Added to store the name of the image file
-}
-
-export interface VotingDevice {
-  id?: number;
-  name: string;         // User-friendly name
-  serialNumber: string; // Unique physical/serial ID (formerly physicalId)
-}
+// Les interfaces QuestionWithId et VotingDevice sont maintenant dans ../types
 
 export class MySubClassedDexie extends Dexie {
   questions!: Table<QuestionWithId, number>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -279,3 +279,51 @@ export interface ThemeScoreDetails {
   correct: number;
   total: number;
 }
+
+// Déplacé depuis db.ts
+export interface QuestionWithId {
+  id?: number;
+  text: string;
+  // type: 'multiple-choice' | 'true-false'; // Remplacé par QuestionType enum
+  type: QuestionType;
+  options: string[];
+  correctAnswer: string;
+  timeLimit?: number;
+  isEliminatory: boolean;
+  blocId?: number;
+  image?: Blob | null;
+  createdAt?: string;
+  updatedAt?: string;
+  usageCount?: number;
+  correctResponseRate?: number;
+  slideGuid?: string;
+  imageName?: string;
+}
+
+// Déplacé depuis db.ts
+export interface VotingDevice {
+  id?: number;
+  name: string;
+  serialNumber: string;
+}
+
+// Déplacé depuis reportCalculators.ts
+export interface CalculatedBlockOverallStats {
+  blocId: number;
+  referentielCode: string;
+  themeCode: string;
+  blocCode: string;
+  usageCount: number;
+  averageSuccessRate: number;
+  averageScore: number;
+}
+
+// Déplacé depuis reportCalculators.ts
+export interface OverallThemeStats {
+  themeId: number;
+  themeCode: string;
+  themeName: string;
+  totalQuestionsAnswered: number;
+  totalCorrectAnswers: number;
+  successRate: number;
+}

--- a/src/utils/reportCalculators.ts
+++ b/src/utils/reportCalculators.ts
@@ -1,4 +1,7 @@
-import { Session, SessionResult, QuestionWithId, SelectedBlock, Referential, Theme, Bloc, ThemeScoreDetails } from '../types'; // Ajout de Referential, Theme, Bloc, ThemeScoreDetails
+import {
+  Session, SessionResult, QuestionWithId, SelectedBlock, Referential, Theme, Bloc,
+  ThemeScoreDetails, CalculatedBlockOverallStats, OverallThemeStats // Types maintenant importés
+} from '../types';
 
 /**
  * Calcule la note globale d'un participant pour une session spécifique.
@@ -194,15 +197,15 @@ import { Session, SessionResult, QuestionWithId, Referential, Theme, Bloc } from
 /**
  * Définit la structure des statistiques retournées pour un bloc.
  */
-export interface CalculatedBlockOverallStats {
-  blocId: number;
-  referentielCode: string;
-  themeCode: string;
-  blocCode: string;
-  usageCount: number; // Nombre de sessions complétées où ce bloc a été utilisé
-  averageSuccessRate: number; // Pourcentage moyen de participants ayant "réussi" le bloc (score >= 50% sur les questions du bloc)
-  averageScore: number; // Score moyen obtenu par les participants sur ce bloc
-}
+// export interface CalculatedBlockOverallStats { // Déplacé vers types/index.ts
+//   blocId: number;
+//   referentielCode: string;
+//   themeCode: string;
+//   blocCode: string;
+//   usageCount: number;
+//   averageSuccessRate: number;
+//   averageScore: number;
+// }
 
 /**
  * Calcule les statistiques de performance pour un BLOC NUMERIQUE ID au sein d'UNE session donnée.
@@ -558,14 +561,14 @@ export interface NumericBlockPerformanceStats {
   successRateOnBlock: number;  // % de participants ayant "réussi" ce bloc (score >= 50%)
 }
 
-export interface OverallThemeStats {
-  themeId: number;
-  themeCode: string;
-  themeName: string;
-  totalQuestionsAnswered: number;
-  totalCorrectAnswers: number;
-  successRate: number;
-}
+// export interface OverallThemeStats { // Déplacé vers types/index.ts
+//   themeId: number;
+//   themeCode: string;
+//   themeName: string;
+//   totalQuestionsAnswered: number;
+//   totalCorrectAnswers: number;
+//   successRate: number;
+// }
 
 /**
  * Calcule les statistiques de performance pour un bloc de questions spécifique au sein d'UNE session donnée.


### PR DESCRIPTION
- Moved type definitions (QuestionWithId, VotingDevice, ThemeScoreDetails, CalculatedBlockOverallStats, OverallThemeStats) to `types/index.ts` for global availability and corrected imports.
- Corrected property access for `referentielId` vs `referentiel` and `selectedBlocIds` vs `selectionBlocs` in CustomReport.tsx and GlobalStats.tsx.
- Fixed type errors in ParticipantReport.tsx related to `originalSessionId`, Badge props, Button onClick signature, and ensured correct usage of `id` and `text` properties for questions.
- Resolved `useMemo` import in BlockUsageReport.tsx.
- Corrected key usage and property access in ReportDetails.tsx for participant data and theme scores.
- Removed unused imports across several report components.
- Addressed various other minor type inconsistencies and warnings.