### PR TITLE
feat: Revamp dashboard and add notifications

### DIFF
--- a/electron/db/questions.ts
+++ b/electron/db/questions.ts
@@ -133,6 +133,19 @@ export const getQuestionById = async (id: number): Promise<QuestionWithId | unde
   });
 }
 
+export const getQuestionCount = async (): Promise<number> => {
+  return asyncDbRun(() => {
+    try {
+      const stmt = getDb().prepare("SELECT COUNT(*) as count FROM questions");
+      const result = stmt.get() as { count: number };
+      return result.count;
+    } catch (error) {
+      logger?.debug(`[DB Questions] Error getting question count: ${error}`);
+      throw error;
+    }
+  });
+};
+
 export const getQuestionsByIds = async (ids: number[]): Promise<QuestionWithId[]> => {
   if (!ids || ids.length === 0) return Promise.resolve([]);
   return asyncDbRun(() => {

--- a/src/components/dashboard/AlertsNotifications.tsx
+++ b/src/components/dashboard/AlertsNotifications.tsx
@@ -1,25 +1,88 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Card from '../ui/Card';
-import { Bell } from 'lucide-react';
+import { Bell, AlertTriangle, FileWarning, HelpCircle } from 'lucide-react';
+import { Session } from '@common/types';
+
+interface AlertData {
+  overdueSessions: Session[];
+  questionCount: number;
+  isOrsPathSet: boolean;
+  isReportPathSet: boolean;
+}
 
 const AlertsNotifications: React.FC = () => {
-  // Logique future pour récupérer et afficher les alertes/notifications
-  const notifications: string[] = []; // Placeholder
+  const [alerts, setAlerts] = useState<AlertData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchAlerts = async () => {
+      setLoading(true);
+      try {
+        if (window.dbAPI?.getDashboardAlerts) {
+          const data = await window.dbAPI.getDashboardAlerts();
+          setAlerts(data);
+        } else {
+          console.error("[AlertsNotifications] dbAPI.getDashboardAlerts is not available.");
+        }
+      } catch (error) {
+        console.error("Erreur lors de la récupération des alertes:", error);
+      }
+      setLoading(false);
+    };
+
+    fetchAlerts();
+  }, []);
+
+  const notificationMessages: React.ReactNode[] = [];
+
+  if (alerts) {
+    if (alerts.overdueSessions.length > 0) {
+      notificationMessages.push(
+        <div key="overdue" className="flex items-start">
+          <AlertTriangle size={18} className="text-yellow-500 mr-3 mt-0.5" />
+          <span>
+            <strong>{alerts.overdueSessions.length} session(s) passée(s)</strong> sont prêtes mais les résultats n'ont pas été importés.
+          </span>
+        </div>
+      );
+    }
+    if (!alerts.isOrsPathSet || !alerts.isReportPathSet) {
+      notificationMessages.push(
+        <div key="paths" className="flex items-start">
+          <FileWarning size={18} className="text-blue-500 mr-3 mt-0.5" />
+          <span>
+            Les <strong>dossiers d'import</strong> pour les présentations ou les rapports ne sont pas configurés.
+          </span>
+        </div>
+      );
+    }
+    if (alerts.questionCount === 0) {
+      notificationMessages.push(
+        <div key="no-questions" className="flex items-start">
+          <HelpCircle size={18} className="text-gray-500 mr-3 mt-0.5" />
+          <span>
+            La <strong>bibliothèque de questions</strong> est vide.
+          </span>
+        </div>
+      );
+    }
+  }
 
   return (
     <Card title="Alertes et Notifications" icon={<Bell size={20} className="text-accent-neutre" />}>
-      {notifications.length === 0 ? (
+      {loading ? (
+        <p className="text-sm text-gray-500 italic">Chargement des notifications...</p>
+      ) : notificationMessages.length === 0 ? (
         <p className="text-sm text-gray-500 italic">Aucune notification pour le moment.</p>
       ) : (
-        <ul className="space-y-2">
-          {notifications.map((notification, index) => (
+        <ul className="space-y-3">
+          {notificationMessages.map((message, index) => (
             <li key={index} className="text-sm text-gray-700">
-              {notification}
+              {message}
             </li>
           ))}
         </ul>
       )}
-      {/* Espace pour des actions futures, ex: "Voir toutes les notifications" */}
     </Card>
   );
 };

--- a/src/components/dashboard/DashboardSessionsOverview.tsx
+++ b/src/components/dashboard/DashboardSessionsOverview.tsx
@@ -81,7 +81,7 @@ const SessionRow: React.FC<{session: Session, onPageChange: (page: string, sessi
               </span>
               <span className="text-gris-moyen hidden sm:inline">•</span>
               <span className="text-sm text-texte-principal/80 block sm:inline mt-1 sm:mt-0">
-                {session.participants ? session.participants.length : 0} participant(s)
+                {session.participantCount ?? 0} participant(s)
               </span>
             </div>
           </div>

--- a/src/components/dashboard/QuickLinks.tsx
+++ b/src/components/dashboard/QuickLinks.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Plus, Upload, FileText, Settings } from 'lucide-react';
+import Card from '../ui/Card';
+import Button from '../ui/Button';
+import { Session } from '@common/types';
+
+type QuickLinksProps = {
+  onPageChange: (page: string, sessionId?: number) => void;
+  sessions: Session[];
+};
+
+const QuickLinks: React.FC<QuickLinksProps> = ({ onPageChange, sessions }) => {
+  const handleNewSession = () => {
+    // This should trigger the same logic as the "Nouvelle session" button in the Sessions page
+    onPageChange('sessions');
+    // The Sessions page should handle the creation state.
+    // We might need to pass a specific state to onPageChange if not.
+    // For now, just navigating to the sessions page seems reasonable.
+    // A more specific implementation might be onPageChange('sessions', { action: 'new' })
+  };
+
+  const handleImportSession = () => {
+    // This should trigger the same logic as the "Importer une session" button in the Sessions page
+    onPageChange('sessions');
+    // Similar to new session, the Sessions page should handle the import trigger.
+  };
+
+  const handleOpenReport = (sessionId: number) => {
+    onPageChange('reports', sessionId);
+  };
+
+  const handleGoToSettings = () => {
+    onPageChange('settings');
+  };
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const completedTodaySessions = sessions.filter(s => {
+    const sessionDate = new Date(s.dateSession);
+    sessionDate.setHours(0, 0, 0, 0);
+    return s.status === 'completed' && sessionDate.getTime() === today.getTime();
+  });
+
+  return (
+    <Card className="mb-6">
+      <h3 className="text-lg font-medium text-texte-principal mb-4">Liens rapides</h3>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Button variant="outline" onClick={() => onPageChange('sessions', undefined)}>
+          <Plus size={16} className="mr-2" />
+          Nouvelle session
+        </Button>
+        <Button variant="outline" onClick={() => onPageChange('sessions', undefined)}>
+          <Upload size={16} className="mr-2" />
+          Importer une session
+        </Button>
+        <Button variant="outline" onClick={handleGoToSettings}>
+          <Settings size={16} className="mr-2" />
+          Paramètres
+        </Button>
+
+        {completedTodaySessions.map(session => (
+          <Button
+            key={session.id}
+            variant="outline"
+            onClick={() => handleOpenReport(session.id!)}
+          >
+            <FileText size={16} className="mr-2" />
+            Rapport: {session.nomSession}
+          </Button>
+        ))}
+      </div>
+    </Card>
+  );
+};
+
+export default QuickLinks;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import Layout from '../components/layout/Layout';
-import DashboardCards from '../components/dashboard/DashboardCards';
 import DashboardSessionsOverview from '../components/dashboard/DashboardSessionsOverview';
 import AlertsNotifications from '../components/dashboard/AlertsNotifications'; // Ajout de l'import
+import QuickLinks from '../components/dashboard/QuickLinks';
 // import QuickActions from '../components/dashboard/QuickActions'; // Supprimé
 // import { mockSessions } from '../data/mockData'; // Plus besoin des mocks ici directement
 // import { getAllSessions } from '../db'; // Supprimé
@@ -69,7 +69,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activePage, onPageChange }) => {
       activePage={activePage}
       onPageChange={onPageChange}
     >
-      <DashboardCards sessions={sessions} />
+      <QuickLinks onPageChange={onPageChange} sessions={sessions} />
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">
         <div className="lg:col-span-2">
           <DashboardSessionsOverview sessions={sessions} onPageChange={onPageChange} referentiels={referentiels} />


### PR DESCRIPTION
This commit introduces several improvements to the dashboard as requested.

A. Deletion / Reorganization:
- Removes the statistics cards from the top of the dashboard.
- Adds a new 'Quick Links' section for creating new sessions, importing sessions, and accessing reports.

B. Alerts and Notifications:
- Adds an alert for sessions that are past their date but have not had results imported.
- Adds a notification for when presentation and report import folders are not set in the technical settings.
- Adds a notification for when there are no questions in the question library.

C. Bug Fixes:
- Corrects the participant count display on the dashboard session cards to show the correct number instead of 0.