### PR TITLE
fix: Resolve blank page on new session creation

### DIFF
--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -121,7 +121,6 @@ const Sessions: React.FC<SessionsProps> = ({ activePage, onPageChange, sessionId
   useEffect(() => {
     if (sessionId !== undefined) {
       setManagingSessionId(sessionId);
-      setIsCreating(false);
       // Charger le nom de la session pour le titre via IPC
       if (window.dbAPI && typeof window.dbAPI.getSessionById === 'function') {
         window.dbAPI.getSessionById(sessionId).then((session: DBSession | undefined) => {
@@ -142,7 +141,6 @@ const Sessions: React.FC<SessionsProps> = ({ activePage, onPageChange, sessionId
     } else {
       setManagingSessionId(null);
       setManagingSessionName(null); // Réinitialiser le nom
-      setIsCreating(false);
     }
   }, [sessionId]);
 


### PR DESCRIPTION
This commit fixes a bug where a blank page was displayed when you were creating a new session from the dashboard's quick links.

The issue was caused by a `useEffect` hook in the `Sessions.tsx` component that was incorrectly resetting the `isCreating` state, overriding the state set by the `sessionStore`. This commit removes the incorrect state modification, ensuring that the session form is displayed correctly when triggered from the dashboard.